### PR TITLE
Strafing Animations & Blend Space

### DIFF
--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/AnimationBlueprints/ABP_PlayerCharacter.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/AnimationBlueprints/ABP_PlayerCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b581927c4a096f73033d17e8f706df45926f3e5e6bee3c04e8113cc99995ac51
-size 161555
+oid sha256:880cfc18fe8dccc72865ae935b550c580ba3fa225aa4aa9b6155fdc03c5a4521
+size 135805

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/AnimationBlueprints/ABP_PlayerCharacter_IK.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/AnimationBlueprints/ABP_PlayerCharacter_IK.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa5b24ecf932a28d288499b862b346b0d7d1c89a489d8b7cd780785d1fac3b4c
-size 69929
+oid sha256:30138c46f624648ca40fb064ce84967d5c95e98b336efb605d5d565caf4987ba
+size 69924

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/AnimationBlueprints/ABP_PlayerCharacter_MainStates.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/AnimationBlueprints/ABP_PlayerCharacter_MainStates.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ff1099aec59196a285efebb75965c9917124f3e44070f88ed1505676e54b5317
-size 311040
+oid sha256:3cc81407d880fd048fd2348223d74e87723e5d198be30b8d1ef83d42d9aefe3d
+size 310975

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/BS_StrafingLocomotion.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/BS_StrafingLocomotion.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f60e80c403d56eed088b1d9a6f7866756f2ece53b8518b89a020cf6ffbd47e2
+size 51964

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runbackward_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runbackward_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08f2792227b55bb35c1446bf086d17be0dc8d746b39f75f39b2e70ca0309bdc0
+size 260090

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runbackwardleft_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runbackwardleft_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2afc196999b3c70b4c30ba144de92b360f8ffd20df42d51ea680e8d9c74448b3
+size 261523

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runbackwardright_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runbackwardright_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:289fae9669762d25a0ccf2e1845dbb1aa4322035f48b8b0b6cfea0eb1d2ef7cb
+size 262211

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runforward_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runforward_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54aff86a7b53718802f0bc4499e36553bf1e52a2e00466d3d28b4cf5677366d8
+size 262040

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runforwardleft_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runforwardleft_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94fa9b8d7089a29fabcf5b7a5d0b32bb39bd119967dc8b1f06503b53f25f6352
+size 262073

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runforwardright_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runforwardright_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b9664a7808d16fddaa23e02c24f61d149e7c59f0297beede0687618b41171cf
+size 261608

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runleft_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runleft_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:196321939dc84bb377d3fb7e2f570d8ddea1bf4f8639619f94b7c1d01bb1621b
+size 261519

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runright_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/runright_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:205548ad6fc8904abd1dc2172626b8f309f4167caf80e03ad5689c1815329010
+size 261984

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintbackward_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintbackward_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31eb9af9270e717e37c171a40f207dfb3fd40ddea5832b2d8f21b4da360c7913
+size 262605

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintbackwardleft_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintbackwardleft_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37c8ac983b0ff89ca2d970a53977aef221abee36b608456c08771783e49b8417
+size 262346

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintbackwardright_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintbackwardright_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01ce680dc64511389f1cc4565698846bcd7267c2d714bbd3ce5771722fd750dd
+size 262534

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintforward_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintforward_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42787286fe4a3313e072a29cc2c94178c9ad3298410ac70ef9f9a6ee11a10f8
+size 262054

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintforwardleft_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintforwardleft_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:448ac88bbdfd9769f2745e92beb7a9d2d031dc485aeab226dfa45e802b7ee146
+size 262319

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintforwardright_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintforwardright_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61de4491f7dedb7f8cc6a60f9e73e686f9927d806a33dffd0bef5b899334d420
+size 260682

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintleft_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintleft_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9de319a65d9f9f237ca69cbc42dc1d86c92de3033263f8c2f34d6aec69871edb
+size 261720

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintright_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/sprintright_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05a8a150899ae5f9ee34ff4ffbc450f5bd59283271865e924a607469a2ae6be5
+size 261449

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkbackward_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkbackward_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48c1c1d569ade24733956e4333571b9e54c4a3025aa8028daebf86f424ddf817
+size 317587

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkbackwardleft_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkbackwardleft_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85443378849af963727aa0d61291726dbaf76c4aece244ece2e251d59577d61d
+size 314650

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkbackwardright_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkbackwardright_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db6a757c2c46698b21c46ad1fb226da196ab26b7ac284eb39f6e8e91a3352794
+size 317643

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkforward_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkforward_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1072564127b38e587737f045caa929b1591cf24dd3d5091e91e60e5d8fe3f37
+size 317529

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkforwardleft_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkforwardleft_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b77d750a90ae9dd95a3cc850c6632f859954f4a604599df73c0b7b4a52312df4
+size 317638

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkforwardright_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkforwardright_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08ad5ef899090c56dc4839c118cb188fdbd0aa679b21e927c817fecdad822fa1
+size 317634

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkleft_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkleft_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da4bb4a06bd1110607dbfdc103b3aca581419eab73fa6a580963304c7b8124c3
+size 317585

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkright_UE.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Animations/Locomotion/StrafingLocomotion/walkright_UE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a56e118a4711ce53be630e210614bd858c9fae9a371aa373f626cc12d3037cd
+size 317527

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/BP_PlayerCharacter.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/BP_PlayerCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f85e59df007a130c31a235cacfe1a90d29be6bbee576e9da46671ddd675e767
-size 40467
+oid sha256:0f9f402616afdc2b953750f2dc64b793b6103257132626c5dc919bf977ab5066
+size 40460

--- a/Content/CPPGameDevCourse/Core/Blueprints/Characters/Input/IA_Interact.uasset
+++ b/Content/CPPGameDevCourse/Core/Blueprints/Characters/Input/IA_Interact.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1e02c11771698137986577b8aebe640c97e643e14adc05ef1699a0d40c7ce76
-size 1709
+oid sha256:1f4e5cca00abe0c42b75a05ad0a6f0b70f4b276ab99cd4e3a24ba4aeb1cecf86
+size 1849

--- a/Content/CPPGameDevCourse/Core/Maps/TestMap.umap
+++ b/Content/CPPGameDevCourse/Core/Maps/TestMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5cf372aeed13f28717b774b5e3e977455dbd2a0ce67965379a02c69f8fc73374
-size 72226
+oid sha256:b5822ddc3729b4006ea0803cf13a2f11c37c689f96d33ccd13635678e718d4ec
+size 67208

--- a/Source/SoulHunter/Private/Characters/PlayerCharacterAnimInstance.cpp
+++ b/Source/SoulHunter/Private/Characters/PlayerCharacterAnimInstance.cpp
@@ -26,5 +26,27 @@ void UPlayerCharacterAnimInstance::NativeUpdateAnimation(float DeltaTime)
 		GroundSpeed = UKismetMathLibrary::VSizeXY(Velocity);
 		IsFalling = PlayerMovementComponent->IsFalling();
 		CharacterState = PlayerCharacter->GetCharacterState();
+		
+		UpdateShouldMove();
+		UpdateDirectionAngle();
 	}
+}
+
+void UPlayerCharacterAnimInstance::UpdateShouldMove()
+{
+	ShouldMove = GroundSpeed > 3.0f &&
+		         !PlayerMovementComponent->GetCurrentAcceleration().IsZero();
+}
+
+void UPlayerCharacterAnimInstance::UpdateDirectionAngle()
+{
+	float DirectionAngle_LastTick = DirectionAngle;
+
+	FRotator ActorRotation = PlayerCharacter->GetActorRotation();
+	float LocalDirection = CalculateDirection(Velocity, ActorRotation);
+
+	if (FMath::IsNearlyEqual(FMath::Abs(LocalDirection), BACKWARD_DIRECTION_CONSTANT, 1.f)) 
+		DirectionAngle = DirectionAngle_LastTick < 0 ? -BACKWARD_DIRECTION_CONSTANT : BACKWARD_DIRECTION_CONSTANT;
+	else
+		DirectionAngle = LocalDirection;
 }

--- a/Source/SoulHunter/Public/Characters/PlayerCharacterAnimInstance.h
+++ b/Source/SoulHunter/Public/Characters/PlayerCharacterAnimInstance.h
@@ -35,6 +35,20 @@ public:
 	UPROPERTY(BlueprintReadOnly, Category = Movement)
 	bool IsFalling;
 
-	UPROPERTY(BlueprintReadOnly, Category = "Movement | Character State")
+	UPROPERTY(BlueprintReadOnly, Category = "Movement")
 	ECharacterState CharacterState;
+
+	UPROPERTY(BlueprintReadOnly, Category = Movement)
+	bool ShouldMove;
+
+	UPROPERTY(BlueprintReadOnly, Category = Movement)
+	float DirectionAngle;
+
+private:
+
+	void UpdateShouldMove();
+
+	void UpdateDirectionAngle();
+
+	const float BACKWARD_DIRECTION_CONSTANT = 180.f;
 };


### PR DESCRIPTION
- Added Strafing Animations
- Created Strafin BlendSpace to use when locked in target (soon to be implemented)

**Important Notes:**
- The strafing animations are based on weapon holding animations, so we will need to use it only as a lower body animation and change the upper body animations depending on the character state or weapon being held